### PR TITLE
Expose showFullScreen and showNormal methods of QMainWindow

### DIFF
--- a/src/QtGui/qmainwindow.cpp
+++ b/src/QtGui/qmainwindow.cpp
@@ -10,6 +10,8 @@ Napi::Object QMainWindowWrap::Init(Napi::Env env, Napi::Object exports)
     // clang-format off
     Napi::Function func = DefineClass(env, "QMainWindow", {
         InstanceMethod("getClosed", &QMainWindowWrap::getClosed),
+        InstanceMethod("showFullScreen", &QMainWindowWrap::showFullScreen),
+        InstanceMethod("showNormal", &QMainWindowWrap::showNormal),
         QWIDGET_JS_DEFINES(QMainWindowWrap)
     });
     // clang-format on
@@ -49,6 +51,18 @@ Napi::Value QMainWindowWrap::getClosed(const Napi::CallbackInfo &info)
     Napi::HandleScope scope(env);
 
     return Napi::Boolean::New(env, q_->closed);
+}
+
+Napi::Value QMainWindowWrap::showFullScreen(const Napi::CallbackInfo &info)
+{
+    q_->showFullScreen();
+    return Napi::Value();
+}
+
+Napi::Value QMainWindowWrap::showNormal(const Napi::CallbackInfo &info)
+{
+    q_->showNormal();
+    return Napi::Value();
 }
 
 // QWidget functions

--- a/src/QtGui/qmainwindow.hpp
+++ b/src/QtGui/qmainwindow.hpp
@@ -22,6 +22,8 @@ private:
   static Napi::FunctionReference constructor;
 
   Napi::Value getClosed(const Napi::CallbackInfo &info);
+  Napi::Value showFullScreen(const Napi::CallbackInfo &info);
+  Napi::Value showNormal(const Napi::CallbackInfo &info);
 
   // QWidget Funcs
   QWIDGET_DEFS


### PR DESCRIPTION
I would love to see fullscreen windows in proton-native. I've manage to get it run locally, but first exposing methods here seems to be required.

I only added support for `showFullScreen` and `showNormal`, without maximized and minimized (I think I have never seen an app using them), but those too can be added too. Or maybe you think it would be better to control it via `setWindowStates(Qt::WindowFullScreen)`?

As there's no readme, I don't know if I should commit `.moc` files. Also version was automatically bumped up and I commited that too.

Let me know what you think.