### PR TITLE
Add setWindowFlags to QMainWindowWrapper

### DIFF
--- a/lib/qt.js
+++ b/lib/qt.js
@@ -32,4 +32,54 @@ qt.AspectRatioMode = {
 };
 Object.freeze(qt.AspectRatioMode);
 
+qt.WindowType = {
+    Widget: 0x00000000,
+    Window: 0x00000001,
+    SubWindow: 0x00000012,
+
+    WindowType_Mask: 0x000000ff,
+    MSWindowsFixedSizeDialogHint: 0x00000100,
+    MSWindowsOwnDC: 0x00000200,
+    BypassWindowManagerHint: 0x00000400,
+    FramelessWindowHint: 0x00000800,
+    WindowTitleHint: 0x00001000,
+    WindowSystemMenuHint: 0x00002000,
+    WindowMinimizeButtonHint: 0x00004000,
+    WindowMaximizeButtonHint: 0x00008000,
+    WindowContextHelpButtonHint: 0x00010000,
+    WindowShadeButtonHint: 0x00020000,
+    WindowStaysOnTopHint: 0x00040000,
+    WindowTransparentForInput: 0x00080000,
+    WindowOverridesSystemGestures: 0x00100000,
+    WindowDoesNotAcceptFocus: 0x00200000,
+    MaximizeUsingFullscreenGeometryHint: 0x00400000,
+
+    CustomizeWindowHint: 0x02000000,
+    WindowStaysOnBottomHint: 0x04000000,
+    WindowCloseButtonHint: 0x08000000,
+    MacWindowToolBarButtonHint: 0x10000000,
+    BypassGraphicsProxyWidget: 0x20000000,
+    NoDropShadowWindowHint: 0x40000000,
+    WindowFullscreenButtonHint: 0x80000000
+};
+qt.WindowType = {
+    ...qt.WindowType,
+    Dialog: 0x00000002 | qt.WindowType.Window,
+    Sheet: 0x00000004 | qt.WindowType.Window,
+    Popup: 0x00000008 | qt.WindowType.Window,
+    Desktop: 0x00000010 | qt.WindowType.Window,
+    ForeignWindow: 0x00000020 | qt.WindowType.Window,
+    CoverWindow: 0x00000040 | qt.WindowType.Window,
+    X11BypassWindowManagerHint: qt.WindowType.BypassWindowManagerHint,
+    WindowMinMaxButtonsHint: qt.WindowType.WindowMinimizeButtonHint | qt.WindowType.WindowMaximizeButtonHint,
+};
+qt.WindowType = {
+    ...qt.WindowType,
+    Drawer: qt.WindowType.Sheet | qt.WindowType.Dialog,
+    Tool: qt.WindowType.Popup | qt.WindowType.Dialog,
+    ToolTip: qt.WindowType.Popup | qt.WindowType.Sheet,
+    SplashScreen: qt.WindowType.Popup | qt.WindowType.Sheet | qt.WindowType.Dialog,
+}
+Object.freeze(qt.WindowType);
+
 module.exports = qt;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-qt-napi",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/QtGui/qapplication.moc
+++ b/src/QtGui/qapplication.moc
@@ -1,18 +1,19 @@
 /****************************************************************************
 ** Meta object code from reading C++ file 'qapplication.hpp'
 **
-** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.5)
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.15.0)
 **
 ** WARNING! All changes made in this file will be lost!
 *****************************************************************************/
 
+#include <memory>
 #include "qapplication.hpp"
 #include <QtCore/qbytearray.h>
 #include <QtCore/qmetatype.h>
 #if !defined(Q_MOC_OUTPUT_REVISION)
 #error "The header file 'qapplication.hpp' doesn't include <QObject>."
 #elif Q_MOC_OUTPUT_REVISION != 67
-#error "This file was generated using the moc from 5.9.5. It"
+#error "This file was generated using the moc from 5.15.0. It"
 #error "cannot be used with the include files from this version of Qt."
 #error "(The moc has changed too much.)"
 #endif
@@ -44,7 +45,7 @@ QT_MOC_LITERAL(2, 39, 0) // ""
 static const uint qt_meta_data_SlotHandlerApplication[] = {
 
  // content:
-       7,       // revision
+       8,       // revision
        0,       // classname
        0,    0, // classinfo
        1,   14, // methods
@@ -66,7 +67,7 @@ static const uint qt_meta_data_SlotHandlerApplication[] = {
 void SlotHandlerApplication::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
 {
     if (_c == QMetaObject::InvokeMetaMethod) {
-        SlotHandlerApplication *_t = static_cast<SlotHandlerApplication *>(_o);
+        auto *_t = static_cast<SlotHandlerApplication *>(_o);
         Q_UNUSED(_t)
         switch (_id) {
         case 0: _t->aboutToQuitSlot(); break;
@@ -76,10 +77,14 @@ void SlotHandlerApplication::qt_static_metacall(QObject *_o, QMetaObject::Call _
     Q_UNUSED(_a);
 }
 
-const QMetaObject SlotHandlerApplication::staticMetaObject = {
-    { &QObject::staticMetaObject, qt_meta_stringdata_SlotHandlerApplication.data,
-      qt_meta_data_SlotHandlerApplication,  qt_static_metacall, nullptr, nullptr}
-};
+QT_INIT_METAOBJECT const QMetaObject SlotHandlerApplication::staticMetaObject = { {
+    QMetaObject::SuperData::link<QObject::staticMetaObject>(),
+    qt_meta_stringdata_SlotHandlerApplication.data,
+    qt_meta_data_SlotHandlerApplication,
+    qt_static_metacall,
+    nullptr,
+    nullptr
+} };
 
 
 const QMetaObject *SlotHandlerApplication::metaObject() const

--- a/src/QtGui/qcombobox.moc
+++ b/src/QtGui/qcombobox.moc
@@ -1,18 +1,19 @@
 /****************************************************************************
 ** Meta object code from reading C++ file 'qcombobox.hpp'
 **
-** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.5)
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.15.0)
 **
 ** WARNING! All changes made in this file will be lost!
 *****************************************************************************/
 
+#include <memory>
 #include "qcombobox.hpp"
 #include <QtCore/qbytearray.h>
 #include <QtCore/qmetatype.h>
 #if !defined(Q_MOC_OUTPUT_REVISION)
 #error "The header file 'qcombobox.hpp' doesn't include <QObject>."
 #elif Q_MOC_OUTPUT_REVISION != 67
-#error "This file was generated using the moc from 5.9.5. It"
+#error "This file was generated using the moc from 5.15.0. It"
 #error "cannot be used with the include files from this version of Qt."
 #error "(The moc has changed too much.)"
 #endif
@@ -46,7 +47,7 @@ QT_MOC_LITERAL(4, 49, 13) // "activatedSlot"
 static const uint qt_meta_data_SlotHandlerComboBox[] = {
 
  // content:
-       7,       // revision
+       8,       // revision
        0,       // classname
        0,    0, // classinfo
        2,   14, // methods
@@ -70,7 +71,7 @@ static const uint qt_meta_data_SlotHandlerComboBox[] = {
 void SlotHandlerComboBox::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
 {
     if (_c == QMetaObject::InvokeMetaMethod) {
-        SlotHandlerComboBox *_t = static_cast<SlotHandlerComboBox *>(_o);
+        auto *_t = static_cast<SlotHandlerComboBox *>(_o);
         Q_UNUSED(_t)
         switch (_id) {
         case 0: _t->currentTextChangedSlot((*reinterpret_cast< const QString(*)>(_a[1]))); break;
@@ -80,10 +81,14 @@ void SlotHandlerComboBox::qt_static_metacall(QObject *_o, QMetaObject::Call _c, 
     }
 }
 
-const QMetaObject SlotHandlerComboBox::staticMetaObject = {
-    { &QObject::staticMetaObject, qt_meta_stringdata_SlotHandlerComboBox.data,
-      qt_meta_data_SlotHandlerComboBox,  qt_static_metacall, nullptr, nullptr}
-};
+QT_INIT_METAOBJECT const QMetaObject SlotHandlerComboBox::staticMetaObject = { {
+    QMetaObject::SuperData::link<QObject::staticMetaObject>(),
+    qt_meta_stringdata_SlotHandlerComboBox.data,
+    qt_meta_data_SlotHandlerComboBox,
+    qt_static_metacall,
+    nullptr,
+    nullptr
+} };
 
 
 const QMetaObject *SlotHandlerComboBox::metaObject() const

--- a/src/QtGui/qlineedit.moc
+++ b/src/QtGui/qlineedit.moc
@@ -1,18 +1,19 @@
 /****************************************************************************
 ** Meta object code from reading C++ file 'qlineedit.hpp'
 **
-** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.5)
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.15.0)
 **
 ** WARNING! All changes made in this file will be lost!
 *****************************************************************************/
 
+#include <memory>
 #include "qlineedit.hpp"
 #include <QtCore/qbytearray.h>
 #include <QtCore/qmetatype.h>
 #if !defined(Q_MOC_OUTPUT_REVISION)
 #error "The header file 'qlineedit.hpp' doesn't include <QObject>."
 #elif Q_MOC_OUTPUT_REVISION != 67
-#error "This file was generated using the moc from 5.9.5. It"
+#error "This file was generated using the moc from 5.15.0. It"
 #error "cannot be used with the include files from this version of Qt."
 #error "(The moc has changed too much.)"
 #endif
@@ -45,7 +46,7 @@ QT_MOC_LITERAL(3, 37, 4) // "text"
 static const uint qt_meta_data_SlotHandlerLineEdit[] = {
 
  // content:
-       7,       // revision
+       8,       // revision
        0,       // classname
        0,    0, // classinfo
        1,   14, // methods
@@ -67,7 +68,7 @@ static const uint qt_meta_data_SlotHandlerLineEdit[] = {
 void SlotHandlerLineEdit::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
 {
     if (_c == QMetaObject::InvokeMetaMethod) {
-        SlotHandlerLineEdit *_t = static_cast<SlotHandlerLineEdit *>(_o);
+        auto *_t = static_cast<SlotHandlerLineEdit *>(_o);
         Q_UNUSED(_t)
         switch (_id) {
         case 0: _t->textChangedSlot((*reinterpret_cast< const QString(*)>(_a[1]))); break;
@@ -76,10 +77,14 @@ void SlotHandlerLineEdit::qt_static_metacall(QObject *_o, QMetaObject::Call _c, 
     }
 }
 
-const QMetaObject SlotHandlerLineEdit::staticMetaObject = {
-    { &QObject::staticMetaObject, qt_meta_stringdata_SlotHandlerLineEdit.data,
-      qt_meta_data_SlotHandlerLineEdit,  qt_static_metacall, nullptr, nullptr}
-};
+QT_INIT_METAOBJECT const QMetaObject SlotHandlerLineEdit::staticMetaObject = { {
+    QMetaObject::SuperData::link<QObject::staticMetaObject>(),
+    qt_meta_stringdata_SlotHandlerLineEdit.data,
+    qt_meta_data_SlotHandlerLineEdit,
+    qt_static_metacall,
+    nullptr,
+    nullptr
+} };
 
 
 const QMetaObject *SlotHandlerLineEdit::metaObject() const

--- a/src/QtGui/qmainwindow.cpp
+++ b/src/QtGui/qmainwindow.cpp
@@ -10,6 +10,7 @@ Napi::Object QMainWindowWrap::Init(Napi::Env env, Napi::Object exports)
     // clang-format off
     Napi::Function func = DefineClass(env, "QMainWindow", {
         InstanceMethod("getClosed", &QMainWindowWrap::getClosed),
+        InstanceMethod("setWindowFlags", &QMainWindowWrap::setWindowFlags),
         QWIDGET_JS_DEFINES(QMainWindowWrap)
     });
     // clang-format on
@@ -49,6 +50,22 @@ Napi::Value QMainWindowWrap::getClosed(const Napi::CallbackInfo &info)
     Napi::HandleScope scope(env);
 
     return Napi::Boolean::New(env, q_->closed);
+}
+
+Napi::Value QMainWindowWrap::setWindowFlags(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+    Napi::Number flags;
+    if (info.Length() <= 0 || !info[0].IsNumber()) {
+        flags = Napi::Number::New(info.Env(), 0);
+    } else {
+        flags = info[0].As<Napi::Number>();
+    }
+
+    q_->setWindowFlags((Qt::WindowFlags)flags.Int32Value());
+
+    return Napi::Boolean::New(env, 1);
 }
 
 // QWidget functions

--- a/src/QtGui/qmainwindow.hpp
+++ b/src/QtGui/qmainwindow.hpp
@@ -22,6 +22,7 @@ private:
   static Napi::FunctionReference constructor;
 
   Napi::Value getClosed(const Napi::CallbackInfo &info);
+  Napi::Value setWindowFlags(const Napi::CallbackInfo &info);
 
   // QWidget Funcs
   QWIDGET_DEFS

--- a/src/QtGui/qplaintextedit.moc
+++ b/src/QtGui/qplaintextedit.moc
@@ -1,18 +1,19 @@
 /****************************************************************************
 ** Meta object code from reading C++ file 'qplaintextedit.hpp'
 **
-** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.5)
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.15.0)
 **
 ** WARNING! All changes made in this file will be lost!
 *****************************************************************************/
 
+#include <memory>
 #include "qplaintextedit.hpp"
 #include <QtCore/qbytearray.h>
 #include <QtCore/qmetatype.h>
 #if !defined(Q_MOC_OUTPUT_REVISION)
 #error "The header file 'qplaintextedit.hpp' doesn't include <QObject>."
 #elif Q_MOC_OUTPUT_REVISION != 67
-#error "This file was generated using the moc from 5.9.5. It"
+#error "This file was generated using the moc from 5.15.0. It"
 #error "cannot be used with the include files from this version of Qt."
 #error "(The moc has changed too much.)"
 #endif
@@ -44,7 +45,7 @@ QT_MOC_LITERAL(2, 41, 0) // ""
 static const uint qt_meta_data_SlotHandlerPlainTextEdit[] = {
 
  // content:
-       7,       // revision
+       8,       // revision
        0,       // classname
        0,    0, // classinfo
        1,   14, // methods
@@ -66,7 +67,7 @@ static const uint qt_meta_data_SlotHandlerPlainTextEdit[] = {
 void SlotHandlerPlainTextEdit::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
 {
     if (_c == QMetaObject::InvokeMetaMethod) {
-        SlotHandlerPlainTextEdit *_t = static_cast<SlotHandlerPlainTextEdit *>(_o);
+        auto *_t = static_cast<SlotHandlerPlainTextEdit *>(_o);
         Q_UNUSED(_t)
         switch (_id) {
         case 0: _t->textChangedSlot(); break;
@@ -76,10 +77,14 @@ void SlotHandlerPlainTextEdit::qt_static_metacall(QObject *_o, QMetaObject::Call
     Q_UNUSED(_a);
 }
 
-const QMetaObject SlotHandlerPlainTextEdit::staticMetaObject = {
-    { &QObject::staticMetaObject, qt_meta_stringdata_SlotHandlerPlainTextEdit.data,
-      qt_meta_data_SlotHandlerPlainTextEdit,  qt_static_metacall, nullptr, nullptr}
-};
+QT_INIT_METAOBJECT const QMetaObject SlotHandlerPlainTextEdit::staticMetaObject = { {
+    QMetaObject::SuperData::link<QObject::staticMetaObject>(),
+    qt_meta_stringdata_SlotHandlerPlainTextEdit.data,
+    qt_meta_data_SlotHandlerPlainTextEdit,
+    qt_static_metacall,
+    nullptr,
+    nullptr
+} };
 
 
 const QMetaObject *SlotHandlerPlainTextEdit::metaObject() const

--- a/src/QtGui/qpushbutton.moc
+++ b/src/QtGui/qpushbutton.moc
@@ -1,18 +1,19 @@
 /****************************************************************************
 ** Meta object code from reading C++ file 'qpushbutton.hpp'
 **
-** Created by: The Qt Meta Object Compiler version 67 (Qt 5.9.5)
+** Created by: The Qt Meta Object Compiler version 67 (Qt 5.15.0)
 **
 ** WARNING! All changes made in this file will be lost!
 *****************************************************************************/
 
+#include <memory>
 #include "qpushbutton.hpp"
 #include <QtCore/qbytearray.h>
 #include <QtCore/qmetatype.h>
 #if !defined(Q_MOC_OUTPUT_REVISION)
 #error "The header file 'qpushbutton.hpp' doesn't include <QObject>."
 #elif Q_MOC_OUTPUT_REVISION != 67
-#error "This file was generated using the moc from 5.9.5. It"
+#error "This file was generated using the moc from 5.15.0. It"
 #error "cannot be used with the include files from this version of Qt."
 #error "(The moc has changed too much.)"
 #endif
@@ -44,7 +45,7 @@ QT_MOC_LITERAL(2, 41, 0) // ""
 static const uint qt_meta_data_SlotHandlerPushButton[] = {
 
  // content:
-       7,       // revision
+       8,       // revision
        0,       // classname
        0,    0, // classinfo
        1,   14, // methods
@@ -66,7 +67,7 @@ static const uint qt_meta_data_SlotHandlerPushButton[] = {
 void SlotHandlerPushButton::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
 {
     if (_c == QMetaObject::InvokeMetaMethod) {
-        SlotHandlerPushButton *_t = static_cast<SlotHandlerPushButton *>(_o);
+        auto *_t = static_cast<SlotHandlerPushButton *>(_o);
         Q_UNUSED(_t)
         switch (_id) {
         case 0: _t->buttonReleasedSlot(); break;
@@ -76,10 +77,14 @@ void SlotHandlerPushButton::qt_static_metacall(QObject *_o, QMetaObject::Call _c
     Q_UNUSED(_a);
 }
 
-const QMetaObject SlotHandlerPushButton::staticMetaObject = {
-    { &QObject::staticMetaObject, qt_meta_stringdata_SlotHandlerPushButton.data,
-      qt_meta_data_SlotHandlerPushButton,  qt_static_metacall, nullptr, nullptr}
-};
+QT_INIT_METAOBJECT const QMetaObject SlotHandlerPushButton::staticMetaObject = { {
+    QMetaObject::SuperData::link<QObject::staticMetaObject>(),
+    qt_meta_stringdata_SlotHandlerPushButton.data,
+    qt_meta_data_SlotHandlerPushButton,
+    qt_static_metacall,
+    nullptr,
+    nullptr
+} };
 
 
 const QMetaObject *SlotHandlerPushButton::metaObject() const


### PR DESCRIPTION
Added `setWindowFlags` to `QMainWindowWrapper`, so we can have stuff like dialogs and chromeless windows.

I see that I have a newer Qt version (5.15.0 vs 5.9.5) but the MOC version is the same, so it should be alright.

**EDIT:** well, Qt version may be alright, but it also uses newer C++ features that the msbuild on the CI doesn't support.